### PR TITLE
Alternative implementation of the winning search algorithm.

### DIFF
--- a/BlazorConnectFour/Data/GameBoard.cs
+++ b/BlazorConnectFour/Data/GameBoard.cs
@@ -61,7 +61,7 @@ namespace BlazorConnectFour.Data
                 // number of cells the same colour - start at 1 for last move
                 var cells = GetMatchingCells(start, direction, colour);
                 Console.WriteLine($"{colour}: {direction} = {cells.Count}");
-                if (cells.Count == WIN) return cells;
+                if (cells.Count >= WIN) return cells;
             }
 
             return null;

--- a/BlazorConnectFour/Data/GameBoard.cs
+++ b/BlazorConnectFour/Data/GameBoard.cs
@@ -7,21 +7,127 @@ namespace BlazorConnectFour.Data
 {
     public class GameBoard
     {
-        public  GamePiece[,] Board { get; set; }
+        public GamePiece[,] Board { get; set; }
 
+        const int MAX_COL = 7;
+        const int MAX_ROW = 6;
 
         public GameBoard()
         {
-            Board = new GamePiece[7, 6];
-           
+            Board = new GamePiece[MAX_COL, MAX_ROW];
+
             //Populate the Board with blank pieces
-            for(int i = 0; i <= 6; i++)
+            for (int i = 0; i < MAX_COL; i++)
             {
-                for(int j = 0; j <= 5; j++)
+                for (int j = 0; j < MAX_ROW; j++)
                 {
                     Board[i, j] = new GamePiece(PieceColor.Blank);
                 }
             }
         }
+
+        /// <summary>
+        /// Get next blank piece (if any)
+        /// </summary>
+        /// <param name="column"></param>
+        /// <returns></returns>
+        public Position GetNextBlank(int column)
+        {
+            // rows at top are 0, last row is 5
+            for (int row = MAX_ROW - 1; row >= 0; row--)
+            {
+                var piece = Board[column, row];
+                if (piece.Color == PieceColor.Blank)
+                    return new Position(column, row);
+            }
+            return null; // column is full
+        }
+
+        /// <summary>
+        /// return cells that make a row of 4, otherwise null
+        /// </summary>
+        /// <param name="col"></param>
+        /// <param name="row"></param>
+        /// <returns></returns>
+        public List<Position> GetWinningMoveCells(Position start)
+        {
+            const int WIN = 4;
+
+            // get colour of counter at last move
+            var colour = Board[start.Column, start.Row].Color;
+
+            foreach (var direction in GetDirections())
+            {
+                // number of cells the same colour - start at 1 for last move
+                var cells = GetMatchingCells(start, direction, colour);
+                Console.WriteLine($"{colour}: {direction} = {cells.Count}");
+                if (cells.Count == WIN) return cells;
+            }
+
+            return null;
+        }
+
+        private Directions[] GetDirections() => (Directions[])Enum.GetValues(typeof(Directions));
+
+
+        /// <summary>
+        /// Returns all matching cells in both directions
+        /// </summary>
+        /// <param name="col"></param>
+        /// <param name="row"></param>
+        /// <param name="direction"></param>
+        /// <param name="colour"></param>
+        /// <returns>List of cell positions with same colour</returns>
+        /// <remarks>
+        /// I returned a list of matching cells so the program could perhaps
+        /// highlight the winning row
+        /// </remarks>
+        private List<Position> GetMatchingCells(Position start, Directions direction, PieceColor colour)
+        {
+            // create a list of matching cells
+            var result = new List<Position>() { start };
+
+            // go in first in one direction, then other
+            foreach (var factor in new int[] { 1, -1 })
+            {
+                for (int step = 1; step <= 3; step++)
+                {
+                    var cell = start.GetOffset(step * factor, direction);
+                    // if invalid (off the board) or not a matching cell, exit loop
+                    if (!cell.IsValid || GetPiece(cell) != colour)
+                        break;
+                    result.Add(cell);
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Get colour of the piece at this position
+        /// </summary>
+        /// <param name="position"></param>
+        /// <returns></returns>
+        private PieceColor GetPiece(Position position)
+        {
+            // bounds check
+            if (!position.IsValid) return PieceColor.Blank;
+            return Board[position.Column, position.Row].Color;
+        }
+
+        /// <summary>
+        /// Determine if a position is valid
+        /// </summary>
+        /// <param name="position">position to check</param>
+        /// <returns></returns>
+        public static bool IsValidPosition(Position position) =>
+            position.Column >= 0 && position.Column < MAX_COL
+            && position.Row >= 0 && position.Row < MAX_ROW;
+
     }
+
+    public enum Directions { Horizontal, Vertical, DiagonalUpRight, DiagonalDownRight }
+
+
+
 }

--- a/BlazorConnectFour/Data/GamePiece.cs
+++ b/BlazorConnectFour/Data/GamePiece.cs
@@ -9,6 +9,8 @@ namespace BlazorConnectFour.Data
     {
         public PieceColor Color;
 
+        public string Winner = null;
+
         public GamePiece()
         {
             Color = PieceColor.Blank;

--- a/BlazorConnectFour/Data/Position.cs
+++ b/BlazorConnectFour/Data/Position.cs
@@ -1,0 +1,40 @@
+﻿using System;
+
+namespace BlazorConnectFour.Data
+{
+    public class Position
+    {
+        public Position(int col, int row)
+        {
+            Column = col;
+            Row = row;
+        }
+
+
+        public int Column { get; set; }
+
+        public int Row { get; set; }
+
+        public bool IsValid => GameBoard.IsValidPosition(this);
+
+        public Position GetOffset(int step, Directions direction)
+        {
+            switch (direction)
+            {
+                case Directions.Horizontal:
+                    return new Position(Column + step, Row);
+
+                case Directions.Vertical:
+                    return new Position(Column, Row + step);
+
+                case Directions.DiagonalUpRight:
+                    return new Position(Column + step, Row + step);
+
+                case Directions.DiagonalDownRight:
+                    return new Position(Column + step, Row - step);
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/BlazorConnectFour/Pages/ConnectFour.razor
+++ b/BlazorConnectFour/Pages/ConnectFour.razor
@@ -5,7 +5,6 @@
 
 @code {
     PieceColor winner = PieceColor.Blank;
-    List<Position> winningCells = null;
 
     GameBoard board = new GameBoard();
     PieceColor currentTurn = PieceColor.Red;
@@ -33,7 +32,11 @@
             {
                 // show winner
                 winner = currentTurn;
-                winningCells = winCells;
+                // set CSS to 'winner'
+                foreach (var position in winCells)
+                {
+                    board.Board[position.Column, position.Row].Winner = "winner";
+                }
             }
         }
         else
@@ -55,17 +58,6 @@
         }
     }
 
-    private string WinningCellCss(int x, int y)
-    {
-        if (winningCells != null)
-        {
-            foreach (var cell in winningCells)
-            {
-                if (cell.Column == x && cell.Row == y) return "winner";
-            }
-        }
-        return string.Empty;
-    }
 }
 
 @if (winner == PieceColor.Blank)
@@ -85,7 +77,8 @@ else
             {
                 var x = i;
                 var y = j;
-                <div class="gamepiece @board.Board[i,j].Color.ToString().ToLower() @WinningCellCss(i,j)"
+                var piece = board.Board[i, j];
+                <div class="gamepiece @piece.Color.ToString().ToLower() @piece.Winner"
                      @onclick="@(() => PieceClicked(x,y))"></div>
             }
         </div>

--- a/BlazorConnectFour/Pages/ConnectFour.razor
+++ b/BlazorConnectFour/Pages/ConnectFour.razor
@@ -4,30 +4,48 @@
 <h1>ConnectFour</h1>
 
 @code {
+    PieceColor winner = PieceColor.Blank;
+    List<Position> winningCells = null;
+
     GameBoard board = new GameBoard();
     PieceColor currentTurn = PieceColor.Red;
 
     private void PieceClicked(int x, int y)
     {
-        var clickedSpace = board.Board[x, y];
-        if (clickedSpace.Color == PieceColor.Blank)
-        {
-            while (y < 5)
-            {
-                var nextSpace = board.Board[x, y + 1];
-                y = y + 1;
-                if (nextSpace.Color == PieceColor.Blank)
-                    clickedSpace = nextSpace;
-            }
-            clickedSpace.Color = currentTurn;
+        // check for a winner - ignore clicks after this point
+        if (winner != PieceColor.Blank) return;
 
-            SwitchTurns();
+        // check the column for next blank cell
+        var move = board.GetNextBlank(x);
+        if (move != null)
+        {
+            var piece = board.Board[move.Column, move.Row];
+            piece.Color = currentTurn;
+
+            // check for a winning move
+            var winCells = board.GetWinningMoveCells(move);
+
+            if (winCells == null)
+            {
+                SwitchTurns();
+            }
+            else
+            {
+                // show winner
+                winner = currentTurn;
+                winningCells = winCells;
+            }
+        }
+        else
+        {
+            // not a valid move - column is full
         }
     }
 
+
     private void SwitchTurns()
     {
-        if(currentTurn == PieceColor.Red)
+        if (currentTurn == PieceColor.Red)
         {
             currentTurn = PieceColor.Yellow;
         }
@@ -36,9 +54,28 @@
             currentTurn = PieceColor.Red;
         }
     }
+
+    private string WinningCellCss(int x, int y)
+    {
+        if (winningCells != null)
+        {
+            foreach (var cell in winningCells)
+            {
+                if (cell.Column == x && cell.Row == y) return "winner";
+            }
+        }
+        return string.Empty;
+    }
 }
 
-<h2>@currentTurn's Turn!</h2>
+@if (winner == PieceColor.Blank)
+{
+    <h2>@currentTurn's Turn!</h2>
+}
+else
+{
+    <h2>@winner has Won!</h2>
+}
 
 <div class="board">
     @for (int i = 0; i < 7; i++)
@@ -48,7 +85,7 @@
             {
                 var x = i;
                 var y = j;
-                <div class="gamepiece @board.Board[i,j].Color.ToString().ToLower()" 
+                <div class="gamepiece @board.Board[i,j].Color.ToString().ToLower() @WinningCellCss(i,j)"
                      @onclick="@(() => PieceClicked(x,y))"></div>
             }
         </div>

--- a/BlazorConnectFour/wwwroot/css/site.css
+++ b/BlazorConnectFour/wwwroot/css/site.css
@@ -181,3 +181,7 @@ app {
 .blank {
     background-color:white;
 }
+
+.winner {
+    border: 4px solid green;
+}


### PR DESCRIPTION
My approach was to use the last move as the starting point, and check in all four directions. Since winner counter can be in the middle of a set of four, we have to check both ways.

Rather than a simple win, I decided to return a list of matching cells, so we can then store the result and change the UI to show the winning set of four. I added a `.winner` css class to highlight the winning cells. I don't think this is the best way - probably adding a `Winner` property to `GamePiece` and setting the CSS that way would be better.

I added a `Position` class as my code initially had a lot of `(int x, int y)` parameters being passed around and it made more sense. I also amended the `PieceClicked` method to check the column.

